### PR TITLE
投稿のBASIC認証を削除/アプリ全体に反映

### DIFF
--- a/app/controllers/portfolio_controller.rb
+++ b/app/controllers/portfolio_controller.rb
@@ -5,7 +5,7 @@ class PortfolioController < ApplicationController
   end
 
   def new
-    basic_auth
+
   end
 
   def edit
@@ -33,12 +33,6 @@ class PortfolioController < ApplicationController
   end
 
   private
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-    end
-  end
 
   def posts_params
     params.permit(:apptitle, :image, :github, :text)


### PR DESCRIPTION
投稿ボタンのBASIC認証を削除した。
https://qiita.com/KazuyaHara/items/f0f6c2efd6414f2f88f7
を参照にしてアプリ全体に認証をかける。